### PR TITLE
Phone search API

### DIFF
--- a/yelp/phone_options.go
+++ b/yelp/phone_options.go
@@ -1,0 +1,28 @@
+package yelp
+
+// PhoneOptions provide search options for phone search. Phone number is
+// required, while country code and category are optional. The latter two
+// enhance the quality of the query.
+type PhoneOptions struct {
+	Phone    string // Parameter that specifies the business phone number to search for. Outside of the US and Canada, include the international dialing code (e.g. +442079460000) or use the 'cc' parameter
+	Cc       string // ISO 3166-1 alpha-2 country code. Default country to us when parsing the phone number. United States = US, Canada = CA, United Kingdom = GB (not UK).
+	Category string // Category to filter search results with. See the list of supported categories. The category filter can be a list of comma delimited categories. For example, 'bars,french' will filter by Bars and French. The category identifier should be used (for example 'discgolf', not 'Disc Golf').
+}
+
+// getParameters will reflect over the values of the given
+// struct, and provide a type appropriate set of querystring parameters
+func (o *PhoneOptions) getParameters() (params map[string]string, err error) {
+	params = make(map[string]string)
+	if o.Phone != "" {
+		params["phone"] = o.Phone
+	} else {
+		return params, errUnspecifiedPhone
+	}
+	if o.Cc != "" {
+		params["cc"] = o.Cc
+	}
+	if o.Category != "" {
+		params["category"] = o.Category
+	}
+	return params, nil
+}

--- a/yelp/phone_options_test.go
+++ b/yelp/phone_options_test.go
@@ -1,0 +1,22 @@
+package yelp
+
+import (
+	"testing"
+)
+
+// TestPhoneSearch will check PhoneSearch using PhoneOptions
+func TestPhoneSearch(t *testing.T) {
+	client := getClient(t)
+	options := PhoneOptions{Phone: "4158632800"} // # of Mission Chinese
+	result, err := client.PhoneSearch(options)
+	check(t, err)
+	assert(t, len(result.Businesses) > 0, containsResults)
+}
+
+// TestPhoneSearchWithoutNumber ensures validation for a phone number when doing a PhoneSearch
+func TestPhoneSearchWithoutNumber(t *testing.T) {
+	client := getClient(t)
+	options := PhoneOptions{}
+	_, err := client.PhoneSearch(options)
+	assert(t, err == errUnspecifiedPhone, shouldRequirePhone)
+}

--- a/yelp/yelp.go
+++ b/yelp/yelp.go
@@ -97,8 +97,14 @@ func (client *Client) GetBusiness(name string) (result Business, err error) {
 // PhoneSearch searches for businesses by phone number
 func (client *Client) PhoneSearch(options PhoneOptions) (result SearchResult, err error) {
 	params, err := options.getParameters()
-	_, err = client.makeRequest(phone, "", params, &result)
 	if err != nil {
+		return SearchResult{}, err
+	}
+	statusCode, err := client.makeRequest(phone, "", params, &result)
+	if err != nil {
+		if statusCode == 400 {
+			return SearchResult{Total: 0}, err
+		}
 		return SearchResult{}, err
 	}
 	return result, nil

--- a/yelp/yelp.go
+++ b/yelp/yelp.go
@@ -21,6 +21,7 @@ const (
 var (
 	errUnspecifiedLocation = errors.New("location must be specified")
 	errBusinessNotFound    = errors.New("business not found")
+	errUnspecifiedPhone    = errors.New("phone number must be specified")
 )
 
 // AuthOptions provide keys required for using the Yelp API.  Find more
@@ -94,8 +95,8 @@ func (client *Client) GetBusiness(name string) (result Business, err error) {
 }
 
 // PhoneSearch searches for businesses by phone number
-func (client *Client) PhoneSearch(number string) (result SearchResult, err error) {
-	params := map[string]string{"phone": number}
+func (client *Client) PhoneSearch(options PhoneOptions) (result SearchResult, err error) {
+	params, err := options.getParameters()
 	_, err = client.makeRequest(phone, "", params, &result)
 	if err != nil {
 		return SearchResult{}, err

--- a/yelp/yelp.go
+++ b/yelp/yelp.go
@@ -15,6 +15,7 @@ const (
 	rootURI      = "http://api.yelp.com/"
 	businessArea = "/v2/business"
 	searchArea   = "/v2/search"
+	phone        = "/v2/phone_search"
 )
 
 var (
@@ -88,6 +89,16 @@ func (client *Client) GetBusiness(name string) (result Business, err error) {
 			return Business{}, errBusinessNotFound
 		}
 		return Business{}, err
+	}
+	return result, nil
+}
+
+// PhoneSearch searches for businesses by phone number
+func (client *Client) PhoneSearch(number string) (result SearchResult, err error) {
+	params := map[string]string{"phone": number}
+	_, err = client.makeRequest(phone, "", params, &result)
+	if err != nil {
+		return SearchResult{}, err
 	}
 	return result, nil
 }

--- a/yelp/yelp_test.go
+++ b/yelp/yelp_test.go
@@ -11,6 +11,7 @@ import (
 const (
 	containsResults       string = "The query returns at least one result."
 	shouldRequireLocation string = "The query should require a location."
+	shouldRequirePhone    string = "The query should require a phone number."
 )
 
 // Check an error result for a value.  If present, fail the test with


### PR DESCRIPTION
Hey, 

I wanted to use the Phone Search API and your package did not have it, so I added it. There's a `PhoneSearch` function, which takes as options a `PhoneOptions` struct, to query the phone search API.

The `PhoneOptions` is made according to the `OptionProvider` interface. The struct requires a phone number as specified in the API docs.

Yelp's Phone Search API docs: https://www.yelp.com/developers/documentation/v2/phone_search

Let me know what you think.
